### PR TITLE
feat: use org name instead

### DIFF
--- a/packages/trycatchfy/README.md
+++ b/packages/trycatchfy/README.md
@@ -2,8 +2,10 @@
 
 Standardize the way you try/catch HTTP request
 
+Are you reading this on `npm`? Check out the [full and updated documentation on GitHub](https://github.com/open-ish/utility/blob/c4edf4815c97bb1f295875cd0d9f2902e28b0dad/packages/trycatchfy/README.md).
+
 ```bash
-npm i utility-trycatchfy
+npm i @open-ish/trycatchfy
 ```
 
 ## Motivation

--- a/packages/trycatchfy/package.json
+++ b/packages/trycatchfy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "utility-trycatchfy",
+  "name": "@open-ish/trycatchfy",
   "version": "0.0.0-semantic-release",
   "type": "commonjs",
   "repository": {
@@ -7,7 +7,9 @@
     "url": "https://github.com/open-ish/utility.git",
     "directory": "packages/trycatchfy"
   },
+  "keywords": ["frontend", "trycatch", "axios", "error handling"],
   "main": "src/index.js",
   "types": "src/index.d.ts",
-  "license": "MIT"
+  "license": "MIT",
+  "readme": "https://github.com/open-ish/utility/blob/master/packages/trycatchfy/README.md"
 }

--- a/packages/trycatchfy/package.json
+++ b/packages/trycatchfy/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/open-ish/utility.git",
     "directory": "packages/trycatchfy"
   },
+  "author": "Open-ish",
   "keywords": ["frontend", "trycatch", "axios", "error handling"],
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,7 @@
       "@open-ish/http-front-cache": ["packages/http-front-cache/src/index.ts"],
       "@open-ish/semantic-release-exec": ["packages/extensions/src/index.ts"],
       "@open-ish/utility-trycatchfy": ["packages/storagefy/src/index.ts"],
-      "@utility/trycatchfy": ["packages/trycatchfy/src/index.ts"]
+      "@open-ish/trycatchfy": ["packages/trycatchfy/src/index.ts"]
     }
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
# What's being delivered?

Moving package name to use @open-ish prefix