### PR TITLE
feat: use org name instead fo all packages

### DIFF
--- a/packages/dependabot-pr-manager/package.json
+++ b/packages/dependabot-pr-manager/package.json
@@ -31,6 +31,5 @@
   },
   "author": {
     "name": "Open-ish"
-  },
-  "readme": "https://github.com/open-ish/utility/tree/master/packages/dependabot-pr-manager/README.md"
+  }
 }

--- a/packages/http-front-cache/package.json
+++ b/packages/http-front-cache/package.json
@@ -13,6 +13,10 @@
     "front",
     "http-front-cache"
   ],
+  "publishConfig": {
+      "access": "public"
+    },
+  "description": "A utility to cache http requests in the front end",
   "author": "Open-ish",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/storagefy/package.json
+++ b/packages/storagefy/package.json
@@ -7,6 +7,12 @@
     "url": "https://github.com/open-ish/utility.git",
     "directory": "packages/storagefy"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "A utility to store data in the browser",
+  "author": "Open-ish",
+  "keywords": ["frontend", "storage", "localStorage", "sessionStorage"],
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "license": "MIT"


### PR DESCRIPTION
BREAKING CHANGE: just using open-ish prefix instead